### PR TITLE
fix file_io operations to throw errors properly

### DIFF
--- a/net/aia_requests.py
+++ b/net/aia_requests.py
@@ -26,15 +26,20 @@ DATE_FMT = '%Y%m%d'
 TIME_FMT = '%H%M%S'
 DATETIME_FMT = f'{DATE_FMT}{TIME_FMT}'
 
-URL_REF = astropy.time.Time('1977-01-01T00:00:00.000', scale='tai', format='isot')
+URL_REF = astropy.time.Time(
+    '1977-01-01T00:00:00.000', scale='tai', format='isot')
 URL_FMT = 'https://sdo7.nascom.nasa.gov/cgi-bin/drms_export.cgi?series=aia__lev1;compress=rice;record={wavelength}_{time}-{time}'
+
 
 @dataclass
 class Config:
     read_timeout: u.s
 
+
 # Configure this to be as you want.
 cfg = Config(10 << u.s)
+
+
 def debug_print(*args, **kwargs):
     logging.info(kwargs.get('sep', ' ').join(str(s) for s in args), **kwargs)
 
@@ -42,7 +47,8 @@ def debug_print(*args, **kwargs):
 class DownloadResult(typing.NamedTuple):
     url: str
     file: str
-    error: Exception=None
+    error: Exception = None
+
     @property
     def success(self):
         return (self.error is None)
@@ -54,8 +60,8 @@ def download_aia_between(
     end: astropy.time.Time,
     wavelengths: list[u.Angstrom],
     fits_out_dir: str,
-    num_jobs: int=8,
-    attempts: int=5
+    num_jobs: int = 8,
+    attempts: int = 5
 ) -> list[DownloadResult]:
     '''
     download AIA fits files given the input args.
@@ -66,15 +72,16 @@ def download_aia_between(
     If the files are available and read locally, then they are ordered by time.
     Else, there's no particular order.
     '''
-    
+
     num_satisfied = 0
     successful = []
     failed = []
     missing_urls = []
-    
+
     # do this sequentially because it's fast
     for w in wavelengths:
-        w_files, w_satisfied = file_io.validate_local_files(fits_out_dir, (start, end), w)
+        w_files, w_satisfied = file_io.validate_local_files(
+            fits_out_dir, (start, end), w)
         num_satisfied += w_satisfied
         successful += [DownloadResult(None, f) for f in w_files]
         if not w_satisfied:
@@ -82,9 +89,10 @@ def download_aia_between(
             w_urls = build_aia_urls(start, end, w)
             missing_urls += get_missing_urls(w_urls, w_files, w)
             debug_print(f'done find {w} urls')
-    
+
     if num_satisfied == len(wavelengths):
-        debug_print(f'all files locally available for wavelengths {wavelengths}, not downloading')
+        debug_print(
+            f'all files locally available for wavelengths {wavelengths}, not downloading')
         return successful
 
     download_wrapper = functools.partial(actual_download_files, fits_out_dir)
@@ -104,18 +112,22 @@ def download_aia_between(
 
         failed = []
         for f in cur_downloaded:
-            if f.success: successful.append(f)
-            else: failed.append(f)
+            if f.success:
+                successful.append(f)
+            else:
+                failed.append(f)
 
         all_successful = (failed == [])
-        if all_successful: break
+        if all_successful:
+            break
         debug_print('some failed ones:\n', failed)
 
         retry = [res.url for res in failed]
-        failed = len(retry)
+        num_failed = len(retry)
         errored_to_print = '\n\t' + '\n\t'.join(retry)
-        print(f'{failed} / {initial_num} downloads failed.')
-        print(f'retrying the following (attempt {1 + tries} / {attempts}): {errored_to_print}')
+        print(f'{num_failed} / {initial_num} downloads failed.')
+        print(
+            f'retrying the following (attempt {1 + tries} / {attempts}): {errored_to_print}')
         missing_urls = copy.deepcopy(retry)
         tries += 1
 
@@ -127,7 +139,7 @@ def build_aia_urls(
     start: astropy.time.Time,
     end: astropy.time.Time,
     wavelength: u.Angstrom,
-    attempts: int=5
+    attempts: int = 5
 ) -> list[str]:
     '''
     build up the download URLS given start, end times and a single wavelength
@@ -155,7 +167,7 @@ def build_aia_urls(
         tries += 1
     if not successful:
         raise RuntimeError('aia_requests.parse_files_ids not successful for '
-            f'wavelength {wavelength}\nlikely a server issue, so try again.')
+                           f'wavelength {wavelength}\nlikely a server issue, so try again.')
 
     req_str = build_request_string(file_ids)
     urls_res = requests.request(
@@ -173,7 +185,8 @@ def build_query_string(start: astropy.time.Time, end: astropy.time.Time, wavelen
     given start, end times and a wavelength,
     return a properly-formatted AIA XML query string.
     '''
-    start_str, end_str = start.strftime(DATETIME_FMT), end.strftime(DATETIME_FMT)
+    start_str, end_str = start.strftime(
+        DATETIME_FMT), end.strftime(DATETIME_FMT)
     wav_num = wavelength.to(u.Angstrom).value
 
     return afx.QUERY_FMT.format(
@@ -223,11 +236,11 @@ def parse_file_ids(query_response: str) -> list[str]:
 
 
 def parse_filename(content_disposition_header: str) -> str:
-  '''
-  get the filename from the response header from AIA
-  this will probably break
-  '''
-  return content_disposition_header.split('"')[-2]
+    '''
+    get the filename from the response header from AIA
+    this will probably break
+    '''
+    return content_disposition_header.split('"')[-2]
 
 
 def extract_urls(request_result: str) -> list[str]:
@@ -298,8 +311,8 @@ def get_missing_urls(
                 t = hdu[1].header['T_REC']
                 t = astropy.time.Time(t, scale='utc', format='isot')
                 file_tais.append(str(t))
-    
     missing_urls = []
+
     for url in urls:
         t = parse.parse(URL_FMT, url)['time']
         t = URL_REF + astropy.time.TimeDelta(t, format='sec')


### PR DESCRIPTION
Sometimes file operations weren't properly finding which files were corrupted. So this fixes that by removing some of the multiprocessing and reapportioning function responsibilities.